### PR TITLE
Adjust Readme to use standard markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Add a button to the toolbar
 
 ## Installation
-Install using /admin/plugins or npm install ep_button_link
-Edit settings in settings.json
+1. Install using /admin/plugins or npm install ep_button_link
+2. Edit settings in settings.json
 
 ## Configuration
 Add the following to your settings.json
@@ -15,10 +15,10 @@ Add the following to your settings.json
   "after": "li[data-key='showTimeSlider']"
 }
 ```
-text = The text of the button, also supports HTML
-link = Where to link to
-classes = the css classes to apply to the button link
-before = The element to draw the button before in the DOM
+text = The text of the button, also supports HTML  
+link = Where to link to  
+classes = the css classes to apply to the button link  
+before = The element to draw the button before in the DOM  
 after = The element to draw the button after in the DOM
 
 Use either before or after..


### PR DESCRIPTION
This makes it to render correctly on [the npm website](https://www.npmjs.com/package/ep_button_link) as they do not seem to use GitHub Flavored Markdown there.